### PR TITLE
hotfix with NPC not throwing on collision with player

### DIFF
--- a/m1wengine/tiles/entities/characters/NPCs/NPC.py
+++ b/m1wengine/tiles/entities/characters/NPCs/NPC.py
@@ -639,7 +639,8 @@ class NPC(Character):
                     raise ValueError(
                         "Unknown caller, cannot set player consume attribute."
                     )
-            elif current_player_action == Actions.throw:
+            else:
+                time.sleep(1)
                 self.set_state_thrown()
 
     def neutral_collided_with_player(self):


### PR DESCRIPTION
hotfix with NPC not throwing on collision with player it will wait 1 second and throw